### PR TITLE
Fix the build with correct reference to app-element

### DIFF
--- a/polymer.json
+++ b/polymer.json
@@ -1,6 +1,6 @@
 {
   "entrypoint": "index.html",
-  "shell": "src/my-app.html",
+  "shell": "src/nyaalert-app.html",
   "sourceGlobs": [
     "src/**/*",
     "images/**/*",


### PR DESCRIPTION
You renamed the app element to `nyaalert-app`, but did not update the `polymer.json`. Now when you execute `polymer build` and then `polymer serve build/default`, the application is working again :tada: 